### PR TITLE
feat(sonification): add sonifer.stop

### DIFF
--- a/.changeset/pink-ghosts-fold.md
+++ b/.changeset/pink-ghosts-fold.md
@@ -1,0 +1,6 @@
+---
+'@uturi/sonification': minor
+'@uturi/uturi': patch
+---
+
+feat(sonification): add Sonifier.stop() to stop current playback, auto-stop previous audio on a new play()

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Uturi is a set of accessibility tools and libraries that give people with disabilities greater autonomy and access to information. The name "Uturi" comes from the Korean folktale "Baby General Uturi" (아기장수 우투리), where Uturi overcomes disabilities and becomes a hero who fights for the weak.
 
+[![home](https://img.shields.io/badge/@uturi)](https://uturi.vercel.app)
+
 ## Mission
 
 Our mission is to make the digital world more inclusive for people with disabilities.
@@ -32,7 +34,7 @@ Uturi strives to:
 ### [@uturi/sonification](https://github.com/ksr20612/uturi/blob/main/packages/sonification/README.md)
 
 [![npm](https://img.shields.io/npm/v/@uturi/sonification.svg)](https://www.npmjs.com/package/@uturi/sonification)
-[![docs](https://img.shields.io/badge/docs-@uturi--sonification-0284c7)](https://uturi.vercel.app/sonification)
+[![docs](https://img.shields.io/badge/docs-@uturi--sonification-0284c7)](https://uturi-sonification-docs.vercel.app/)
 
 A data sonification library that transforms numerical data into musical melodies, enabling visually impaired users to experience data audibly. Inspired by synesthesia—a condition where people experience colors when hearing music—and synesthetic imagery in literature, this library bridges the gap between visual and auditory perception.
 
@@ -45,7 +47,7 @@ A data sonification library that transforms numerical data into musical melodies
 - **Web Worker Support**: Audio generation in background thread for better performance
 - **Accessibility Focused**: An alternative to data visualization for the visually impaired
 
-[View Documentation →](https://github.com/ksr20612/uturi/blob/main/packages/sonification/README.md) | [Try Demo →](https://uturi.vercel.app/sonification)
+[View Documentation →](https://uturi-sonification-docs.vercel.app/) | [Try Demo →](https://uturi-sonification-docs.vercel.app/docs#live-demo)
 
 ## License
 

--- a/apps/docs/components/SonificationDemo.tsx
+++ b/apps/docs/components/SonificationDemo.tsx
@@ -127,7 +127,7 @@ export function SonificationDemo() {
   const [dataSamples, setDataSamples] = useState(DEFAULT_DATA);
   const [localError, setLocalError] = useState<string | null>(null);
 
-  const { sonify, isPlaying, error, setConfig: updateConfig } = useSonifier(config);
+  const { sonify, stop, isPlaying, error, setConfig: updateConfig } = useSonifier(config);
   const configUpdateTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -299,6 +299,14 @@ export function SonificationDemo() {
           className="rounded-md bg-fd-primary px-3 py-1.5 text-sm font-medium text-fd-primary-foreground transition hover:opacity-90 disabled:opacity-60"
         >
           {isPlaying ? 'Playing...' : 'Sonify'}
+        </button>
+        <button
+          type="button"
+          onClick={stop}
+          disabled={!isPlaying}
+          className="rounded-md border border-fd-border px-3 py-1.5 text-sm font-medium text-fd-foreground transition hover:bg-fd-accent disabled:opacity-60"
+        >
+          Stop
         </button>
       </div>
     </div>

--- a/apps/docs/content/docs/advanced.mdx
+++ b/apps/docs/content/docs/advanced.mdx
@@ -23,7 +23,11 @@ const sonifier = new Sonifier();
 const result = await sonifier.sonify(data, 'melody', { autoPlay: false });
 
 // Play later
-await sonifier.play(result.audioBuffer);
+const playback = sonifier.play(result.audioBuffer);
+
+// Stop early if needed
+sonifier.stop();
+await playback;
 
 // Or use the AudioBuffer with other Web Audio API features
 const audioContext = new AudioContext();

--- a/apps/docs/content/docs/api.mdx
+++ b/apps/docs/content/docs/api.mdx
@@ -53,7 +53,7 @@ await sonifier.play(result.audioBuffer);
 
 ### `getConfig()` / `setConfig(config)`
 
-Read or update configuration. `setConfig` merges with defaults and re-validates.
+Read or update configuration. `setConfig` merges the provided fields into the **current** config and re-validates. Unspecified fields keep their existing values.
 
 ### `cleanup()`
 

--- a/apps/docs/content/docs/api.mdx
+++ b/apps/docs/content/docs/api.mdx
@@ -18,6 +18,7 @@ class Sonifier {
   ): Promise<SonifierResult>;
 
   play(audioBuffer: AudioBuffer): Promise<void>;
+  stop(): void;
   getConfig(): Required<SonifierConfig>;
   setConfig(config: SonifierConfig): void;
   cleanup(): void;
@@ -44,11 +45,24 @@ const result = await sonifier.sonify([10, 20, 30, 40, 50], 'melody', {
 
 ### `play(audioBuffer)`
 
-Plays an `AudioBuffer` through the Sonifier instance.
+Plays an `AudioBuffer` through the Sonifier instance. Starting a new playback automatically stops any previous one.
 
 ```ts
 const result = await sonifier.sonify(data, 'frequency');
 await sonifier.play(result.audioBuffer);
+```
+
+### `stop()`
+
+Stops the currently playing audio, if any, and resolves the pending `play()` promise. Does **not** cancel in-flight audio generation from `sonify()`.
+
+```ts
+const result = await sonifier.sonify(data, 'melody');
+const playback = sonifier.play(result.audioBuffer);
+
+// Later
+sonifier.stop();
+await playback; // resolves when stopped
 ```
 
 ### `getConfig()` / `setConfig(config)`

--- a/apps/docs/content/docs/configuration.mdx
+++ b/apps/docs/content/docs/configuration.mdx
@@ -62,6 +62,8 @@ await sonifier.sonify(salesData, 'frequency', { autoPlay: true });
 
 ## Dynamic updates
 
+`setConfig` applies a partial update on top of the current configuration. Fields you omit are left unchanged.
+
 ```ts
 const sonifier = new Sonifier({
   duration: 2.0,
@@ -73,6 +75,11 @@ sonifier.setConfig({
   duration: 4.0,
   volume: 0.6,
   waveType: 'square',
+});
+
+// Only change waveform; duration and volume stay at 4.0 / 0.6
+sonifier.setConfig({
+  waveType: 'sawtooth',
 });
 
 const currentConfig = sonifier.getConfig();

--- a/apps/docs/content/docs/frameworks.mdx
+++ b/apps/docs/content/docs/frameworks.mdx
@@ -12,10 +12,11 @@ They differ only in how reactive state is exposed.
 | --- | --- |
 | `sonify` | `(data, method, options?) => Promise<SonifierResult>` |
 | `play` | `(audioBuffer) => Promise<void>` |
+| `stop` | `() => void` — stops current playback (does not cancel generation) |
 | `getConfig` | `() => Required<SonifierConfig>` |
 | `setConfig` | `(config) => void` |
 | `getSonifier` | `() => Sonifier` |
-| `isPlaying` | Whether audio is currently playing |
+| `isPlaying` | Whether a sonify or play operation is in progress |
 | `error` | Last `SonificationError` or `null` |
 | `result` | Last `SonifierResult` or `null` |
 
@@ -29,6 +30,7 @@ import { useSonifier } from '@uturi/sonification/react';
 const {
   sonify,
   play,
+  stop,
   getConfig,
   setConfig,
   isPlaying, // boolean
@@ -48,6 +50,7 @@ import { useSonifier } from '@uturi/sonification/vue';
 const {
   sonify,
   play,
+  stop,
   getConfig,
   setConfig,
   isPlaying, // Ref<boolean>
@@ -67,6 +70,7 @@ import { useSonifier } from '@uturi/sonification/svelte';
 const {
   sonify,
   play,
+  stop,
   getConfig,
   setConfig,
   isPlaying, // Writable<boolean>

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -20,7 +20,7 @@ Inspired by synesthesia—experiencing one sense through another, such as seeing
 
 ## Live Demo
 
-Try converting a sample dataset into sound. Change the method or waveform, then press **Sonify**.
+Try converting a sample dataset into sound. Change the method or waveform, then press **Sonify**. Use **Stop** to end playback early while audio is playing.
 
 <SonificationDemo />
 

--- a/apps/docs/content/docs/quick-start.mdx
+++ b/apps/docs/content/docs/quick-start.mdx
@@ -11,11 +11,18 @@ import { Sonifier } from '@uturi/sonification';
 const data = [10, 50, 30, 80, 20, 90, 40, 70];
 const sonifier = new Sonifier();
 
-const result = await sonifier.sonify(data, 'frequency', { autoPlay: true });
+const result = await sonifier.sonify(data, 'frequency');
+const playback = sonifier.play(result.audioBuffer);
+
+// Stop playback early while audio is playing
+sonifier.stop();
+await playback;
 
 console.log('Generated data points:', result.dataPoints);
 console.log('Audio duration:', result.duration);
 ```
+
+Call `stop()` while audio is playing to end playback. It does not cancel in-flight audio generation.
 
 ## React
 
@@ -25,7 +32,7 @@ import { useCallback } from 'react';
 
 function ChartWithSound() {
   const chartData = [10, 25, 15, 40, 35, 60];
-  const { sonify, isPlaying, error, result } = useSonifier({
+  const { sonify, stop, isPlaying, error, result } = useSonifier({
     duration: 2.0,
     volume: 0.5,
   });
@@ -43,6 +50,9 @@ function ChartWithSound() {
     <div>
       <button onClick={handlePlaySound} disabled={isPlaying}>
         {isPlaying ? 'Playing...' : 'Play Chart Sound'}
+      </button>
+      <button onClick={stop} disabled={!isPlaying}>
+        Stop
       </button>
       {error && (
         <div>
@@ -63,7 +73,7 @@ function ChartWithSound() {
 import { useSonifier } from '@uturi/sonification/vue';
 
 const chartData = [10, 25, 15, 40, 35, 60];
-const { sonify, isPlaying, error, result } = useSonifier({
+const { sonify, stop, isPlaying, error, result } = useSonifier({
   duration: 2.0,
   volume: 0.5,
 });
@@ -82,6 +92,7 @@ const handlePlaySound = async () => {
     <button @click="handlePlaySound" :disabled="isPlaying">
       {{ isPlaying ? 'Playing...' : 'Play Chart Sound' }}
     </button>
+    <button @click="stop" :disabled="!isPlaying">Stop</button>
     <div v-if="error">
       Error: {{ error.message }}
       <span v-if="error.code"> ({{ error.code }})</span>
@@ -98,7 +109,7 @@ const handlePlaySound = async () => {
   import { useSonifier } from '@uturi/sonification/svelte';
 
   const chartData = [10, 25, 15, 40, 35, 60];
-  const { sonify, isPlaying, error, result } = useSonifier({
+  const { sonify, stop, isPlaying, error, result } = useSonifier({
     duration: 2.0,
     volume: 0.5,
   });
@@ -115,6 +126,7 @@ const handlePlaySound = async () => {
 <button on:click={handlePlaySound} disabled={$isPlaying}>
   {$isPlaying ? 'Playing...' : 'Play Chart Sound'}
 </button>
+<button on:click={stop} disabled={!$isPlaying}>Stop</button>
 {#if $error}
   <div>
     Error: {$error.message}

--- a/apps/docs/next-env.d.ts
+++ b/apps/docs/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/docs/next-env.d.ts
+++ b/apps/docs/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/sonification/README.md
+++ b/packages/sonification/README.md
@@ -272,11 +272,16 @@ const sonifier = new Sonifier({
   maxRhythm: 0.9, // Maximum rhythm
 });
 
-// Configuration can also be updated dynamically
+// Configuration can also be updated dynamically (partial merge into current config)
 sonifier.setConfig({
   duration: 4.0,
   volume: 0.6,
   waveType: 'sawtooth', // Change waveform type
+});
+
+// Only change waveform; duration and volume stay at 4.0 / 0.6
+sonifier.setConfig({
+  waveType: 'square',
 });
 
 const result = await sonifier.sonify(salesData, 'frequency', { autoPlay: true });
@@ -302,10 +307,14 @@ class Sonifier {
 
   play(audioBuffer: AudioBuffer): Promise<void>;
   getConfig(): Required<SonifierConfig>;
-  setConfig(config: SonifierConfig): void;
+  setConfig(config: SonifierConfig): void; // merges into current config
   cleanup(): void;
 }
 ```
+
+#### `getConfig()` / `setConfig(config)`
+
+Read or update configuration. `setConfig` merges the provided fields into the **current** config and re-validates. Unspecified fields keep their existing values.
 
 #### `sonify(data, method, options?)`
 

--- a/packages/sonification/README.md
+++ b/packages/sonification/README.md
@@ -13,9 +13,10 @@ A data sonification library that transforms numerical data into musical melodies
 - **Comprehensive Error Handling**: Custom error classes with error codes for better error management
 - **Accessibility Focused**: An alternative to data visualization for the visually impaired
 
-## Demo
+## Documentation
 
-open https://uturi.vercel.app/sonification
+- [Developer Docs](https://uturi-sonification-docs.vercel.app/)
+- [Live Demo](https://uturi-sonification-docs.vercel.app/docs#live-demo)
 
 ## Installation
 
@@ -639,5 +640,6 @@ This project is licensed under the MIT License. See the [LICENSE](LICENSE) file 
 
 ## Related Links
 
+- [Documentation](https://uturi-sonification-docs.vercel.app/)
 - [GitHub Repository](https://github.com/ksr20612/uturi/tree/main/packages/sonification)
 - [Issue Tracker](https://github.com/ksr20612/uturi/issues)

--- a/packages/sonification/README.md
+++ b/packages/sonification/README.md
@@ -306,6 +306,7 @@ class Sonifier {
   ): Promise<SonifierResult>;
 
   play(audioBuffer: AudioBuffer): Promise<void>;
+  stop(): void;
   getConfig(): Required<SonifierConfig>;
   setConfig(config: SonifierConfig): void; // merges into current config
   cleanup(): void;
@@ -338,7 +339,7 @@ const result = await sonifier.sonify([10, 20, 30, 40, 50], 'melody', {
 
 #### `play(audioBuffer)`
 
-Plays an AudioBuffer through the Sonifier instance.
+Plays an AudioBuffer through the Sonifier instance. Starting a new playback automatically stops any previous one.
 
 **Parameters:**
 
@@ -353,6 +354,18 @@ const result = await sonifier.sonify(data, 'frequency');
 await sonifier.play(result.audioBuffer);
 ```
 
+#### `stop()`
+
+Stops the currently playing audio, if any, and resolves the pending `play()` promise. Does **not** cancel in-flight audio generation from `sonify()`.
+
+```typescript
+const result = await sonifier.sonify(data, 'melody');
+const playback = sonifier.play(result.audioBuffer);
+
+sonifier.stop();
+await playback;
+```
+
 ### Framework Hooks
 
 #### React: `useSonifier(initialConfig?)`
@@ -363,6 +376,7 @@ import { useSonifier } from '@uturi/sonification/react';
 const {
   sonify, // (data, method, options?) => Promise<SonifierResult>
   play, // (audioBuffer) => Promise<void>
+  stop, // () => void
   getConfig, // () => Required<SonifierConfig>
   setConfig, // (config) => void
   isPlaying, // boolean
@@ -380,6 +394,7 @@ import { useSonifier } from '@uturi/sonification/vue';
 const {
   sonify, // (data, method, options?) => Promise<SonifierResult>
   play, // (audioBuffer) => Promise<void>
+  stop, // () => void
   getConfig, // () => Required<SonifierConfig>
   setConfig, // (config) => void
   isPlaying, // Ref<boolean>
@@ -397,6 +412,7 @@ import { useSonifier } from '@uturi/sonification/svelte';
 const {
   sonify, // (data, method, options?) => Promise<SonifierResult>
   play, // (audioBuffer) => Promise<void>
+  stop, // () => void
   getConfig, // () => Required<SonifierConfig>
   setConfig, // (config) => void
   isPlaying, // Writable<boolean>
@@ -492,7 +508,11 @@ const sonifier = new Sonifier();
 const result = await sonifier.sonify(data, 'melody', { autoPlay: false });
 
 // Play later
-await sonifier.play(result.audioBuffer);
+const playback = sonifier.play(result.audioBuffer);
+
+// Stop early if needed
+sonifier.stop();
+await playback;
 
 // Or use the AudioBuffer with other Web Audio API features
 const audioContext = new AudioContext();

--- a/packages/sonification/package.json
+++ b/packages/sonification/package.json
@@ -93,7 +93,7 @@
     "url": "https://github.com/ksr20612/uturi.git",
     "directory": "packages/sonification"
   },
-  "homepage": "https://github.com/ksr20612/uturi/tree/main/packages/sonification#readme",
+  "homepage": "https://uturi-sonification-docs.vercel.app/",
   "bugs": {
     "url": "https://github.com/ksr20612/uturi/issues"
   }

--- a/packages/sonification/src/core/Sonifier.ts
+++ b/packages/sonification/src/core/Sonifier.ts
@@ -102,7 +102,7 @@ export default class Sonifier {
 
   setConfig(config: SonifierConfig): void {
     const mergedConfig = {
-      ...defaultConfig,
+      ...this.config,
       ...config,
     };
 

--- a/packages/sonification/src/core/Sonifier.ts
+++ b/packages/sonification/src/core/Sonifier.ts
@@ -17,6 +17,8 @@ export default class Sonifier {
   private oscillator: Oscillator;
   private worker: Worker | null = null;
   private isWorkerSupported: boolean;
+  private currentSource: AudioBufferSourceNode | null = null;
+  private playResolve: (() => void) | null = null;
 
   constructor(config: SonifierConfig = {}) {
     const mergedConfig = {
@@ -69,6 +71,8 @@ export default class Sonifier {
 
   async play(audioBuffer: AudioBuffer): Promise<void> {
     try {
+      this.stop();
+
       const audioContext = this.getAudioContext();
 
       if (audioContext.state === 'suspended') {
@@ -78,10 +82,19 @@ export default class Sonifier {
       const source = audioContext.createBufferSource();
       source.buffer = audioBuffer;
       source.connect(audioContext.destination);
+      this.currentSource = source;
       source.start();
 
       return new Promise((resolve) => {
-        source.onended = () => resolve();
+        this.playResolve = resolve;
+        source.onended = () => {
+          if (this.currentSource === source) {
+            this.currentSource = null;
+          }
+          const playResolve = this.playResolve;
+          this.playResolve = null;
+          playResolve?.();
+        };
       });
     } catch (error) {
       if (error instanceof SonificationError) {
@@ -94,6 +107,30 @@ export default class Sonifier {
         { cause: error instanceof Error ? error : undefined },
       );
     }
+  }
+
+  /**
+   * Stops the currently playing audio, if any.
+   * Resolves any pending `play()` promise. Does not cancel in-flight audio generation.
+   */
+  stop(): void {
+    const source = this.currentSource;
+    if (!source) {
+      return;
+    }
+
+    this.currentSource = null;
+    source.onended = null;
+
+    try {
+      source.stop();
+    } catch {
+      // Already stopped or never started
+    }
+
+    const playResolve = this.playResolve;
+    this.playResolve = null;
+    playResolve?.();
   }
 
   getConfig(): Required<SonifierConfig> {
@@ -112,6 +149,8 @@ export default class Sonifier {
   }
 
   cleanup(): void {
+    this.stop();
+
     if (this.audioContext) {
       this.audioContext.close();
       this.audioContext = null;

--- a/packages/sonification/src/react/useSonifier.ts
+++ b/packages/sonification/src/react/useSonifier.ts
@@ -124,6 +124,14 @@ export function useSonifier(initialConfig?: SonifierConfig) {
     [sonifier],
   );
 
+  /**
+   * Stops the currently playing audio, if any.
+   * Does not cancel in-flight audio generation.
+   */
+  const stop = useCallback(() => {
+    sonifier.stop();
+  }, [sonifier]);
+
   useEffect(() => {
     return () => {
       sonifier.cleanup();
@@ -135,6 +143,8 @@ export function useSonifier(initialConfig?: SonifierConfig) {
     sonify,
     /** Plays an AudioBuffer */
     play,
+    /** Stops the currently playing audio */
+    stop,
     /** Returns current configuration */
     getConfig,
     /** Updates Sonifier configuration */

--- a/packages/sonification/src/svelte/useSonifier.ts
+++ b/packages/sonification/src/svelte/useSonifier.ts
@@ -122,6 +122,14 @@ export function useSonifier(initialConfig?: SonifierConfig) {
     }
   };
 
+  /**
+   * Stops the currently playing audio, if any.
+   * Does not cancel in-flight audio generation.
+   */
+  const stop = (): void => {
+    sonifierInstance.stop();
+  };
+
   // Cleanup on component destroy
   onDestroy(() => {
     sonifierInstance.cleanup();
@@ -132,6 +140,8 @@ export function useSonifier(initialConfig?: SonifierConfig) {
     sonify,
     /** Plays an AudioBuffer */
     play,
+    /** Stops the currently playing audio */
+    stop,
     /** Returns current configuration */
     getConfig,
     /** Updates Sonifier configuration */

--- a/packages/sonification/src/vue/useSonifier.ts
+++ b/packages/sonification/src/vue/useSonifier.ts
@@ -122,6 +122,14 @@ export function useSonifier(initialConfig?: SonifierConfig) {
     }
   };
 
+  /**
+   * Stops the currently playing audio, if any.
+   * Does not cancel in-flight audio generation.
+   */
+  const stop = (): void => {
+    sonifierInstance.value.stop();
+  };
+
   onUnmounted(() => {
     sonifierInstance.value.cleanup();
   });
@@ -131,6 +139,8 @@ export function useSonifier(initialConfig?: SonifierConfig) {
     sonify,
     /** Plays an AudioBuffer */
     play,
+    /** Stops the currently playing audio */
+    stop,
     /** Returns current configuration */
     getConfig,
     /** Updates Sonifier configuration */

--- a/packages/sonification/tests/integration/Sonifier.integration.test.ts
+++ b/packages/sonification/tests/integration/Sonifier.integration.test.ts
@@ -284,6 +284,54 @@ describe('Sonifier Integration Test - Web Audio API Polyfill', () => {
       expect(result.audioBuffer).toBeDefined();
       expect(result.dataPoints.length).toBe(testData.length);
     });
+
+    it('stop 호출 시 재생이 중단되고 play Promise가 resolve 되어야 함', async () => {
+      const playPromise = sonifier.play(audioBufferMock as unknown as AudioBuffer);
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const [audioBufferSourceNodeMock] = registrar.getAudioNodes(
+        audioContextMock,
+        'AudioBufferSourceNode',
+      );
+
+      expect(audioBufferSourceNodeMock).toBeDefined();
+
+      sonifier.stop();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((audioBufferSourceNodeMock.stop as any).called).toBe(true);
+      await expect(playPromise).resolves.not.toThrow();
+    });
+
+    it('연속 play 호출 시 이전 재생이 중단되어야 함', async () => {
+      const firstPlay = sonifier.play(audioBufferMock as unknown as AudioBuffer);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const secondBuffer = new AudioBufferMock({ length: 10, sampleRate: 44100 });
+      const secondPlay = sonifier.play(secondBuffer as unknown as AudioBuffer);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const nodes = registrar.getAudioNodes(audioContextMock, 'AudioBufferSourceNode');
+      expect(nodes.length).toBeGreaterThanOrEqual(2);
+
+      const firstNode = nodes[0];
+      const secondNode = nodes[nodes.length - 1];
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((firstNode.stop as any).called).toBe(true);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((secondNode.start as any).called).toBe(true);
+
+      await expect(firstPlay).resolves.not.toThrow();
+
+      sonifier.stop();
+      await expect(secondPlay).resolves.not.toThrow();
+    });
+
+    it('재생 중이 아닐 때 stop을 호출해도 예외가 발생하지 않아야 함', () => {
+      expect(() => sonifier.stop()).not.toThrow();
+    });
   });
 
   describe('설정 관리 검증', () => {

--- a/packages/sonification/tests/integration/Sonifier.integration.test.ts
+++ b/packages/sonification/tests/integration/Sonifier.integration.test.ts
@@ -326,6 +326,27 @@ describe('Sonifier Integration Test - Web Audio API Polyfill', () => {
       expect(updatedConfig.duration).toBe(3.0);
       expect(updatedConfig.frequency).toBe(initialConfig.frequency);
     });
+
+    it('setConfig 부분 업데이트 시 기존 커스텀 설정을 유지해야 함', () => {
+      const customSonifier = new Sonifier({
+        duration: 3.0,
+        volume: 0.8,
+        minFrequency: 200,
+        maxFrequency: 800,
+        waveType: 'sine',
+      });
+
+      customSonifier.setConfig({ waveType: 'square' });
+      const config = customSonifier.getConfig();
+
+      expect(config.waveType).toBe('square');
+      expect(config.duration).toBe(3.0);
+      expect(config.volume).toBe(0.8);
+      expect(config.minFrequency).toBe(200);
+      expect(config.maxFrequency).toBe(800);
+
+      customSonifier.cleanup();
+    });
   });
 
   describe('에러 처리 검증', () => {

--- a/packages/sonification/tests/unit/SonificationEngine.test.ts
+++ b/packages/sonification/tests/unit/SonificationEngine.test.ts
@@ -115,4 +115,39 @@ describe('SonificationEngine', () => {
       expect(config.frequency).toBe(825);
     });
   });
+
+  describe('setConfig 메서드', () => {
+    it('부분 업데이트 시 기존 커스텀 설정을 유지해야 한다', () => {
+      const customEngine = new Sonifier({
+        duration: 3.0,
+        volume: 0.8,
+        minFrequency: 200,
+        maxFrequency: 800,
+        waveType: 'sine',
+      });
+
+      customEngine.setConfig({ waveType: 'square' });
+      const config = customEngine.getConfig();
+
+      expect(config.waveType).toBe('square');
+      expect(config.duration).toBe(3.0);
+      expect(config.volume).toBe(0.8);
+      expect(config.minFrequency).toBe(200);
+      expect(config.maxFrequency).toBe(800);
+    });
+
+    it('지정한 필드만 덮어써야 한다', () => {
+      const customEngine = new Sonifier({
+        duration: 3.0,
+        volume: 0.8,
+      });
+
+      customEngine.setConfig({ duration: 5.0 });
+      const config = customEngine.getConfig();
+
+      expect(config.duration).toBe(5.0);
+      expect(config.volume).toBe(0.8);
+      expect(config.sampleRate).toBe(44100);
+    });
+  });
 });

--- a/packages/uturi/next-env.d.ts
+++ b/packages/uturi/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
# Pull Request

## Package

Select the package(s) affected by this PR (at least one):

- [x] @uturi/sonification
- [x] @uturi/docs (docs)
- [ ] @uturi/uturi (website)
- [x] Root / General documentation
- [ ] Other / Multiple packages

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] 🧪 Test update

## Description

Please include a summary of the change and the motivation behind it.

- Add `Sonifier.stop()` to stop current playback, auto-stop previous audio on a new `play()`, and call `stop()` from `cleanup()`; expose `stop` on React/Vue/Svelte hooks.
- Fix `Sonifier.setConfig` to merge into the current config instead of resetting unspecified fields to defaults; update docs/README and add unit/integration tests.

---

## Related Issue

- Issue number (if applicable): #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `stop()` control to stop active playback without canceling audio generation.
  * Added Stop buttons to documentation demos and framework examples.
  * Starting new playback now replaces any currently playing audio.
* **Improvements**
  * Partial configuration updates now preserve settings that are not changed.
  * Playback state and completion behavior are handled more consistently.
* **Documentation**
  * Updated API, configuration, and usage guides with stopping and playback details.
  * Refreshed documentation, demo, and homepage links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->